### PR TITLE
Resolves #1 - Allow for smart file sniffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ mongonaut.import('./data.json')
 
 **returns:** mongonaut
 
-### .import(jsonFile)
-**jsonFile:** The JSON file containing the data you wish to [import to MongoDB](https://docs.mongodb.org/manual/reference/program/mongoimport/).
+### .import(targetFile)
+**targetFile:** The file (.json, .csv, or .tsv) containing the data you wish to [import to MongoDB](https://docs.mongodb.org/manual/reference/program/mongoimport/).
 
 **returns:** [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,5 +1,13 @@
 'use strict';
 
 module.exports = function (target) {
-  return `mongoimport --host localhost --db ${this.config.db} -u ${this.config.user} -p ${this.config.pwd} --authenticationDatabase ${this.config.db} --collection ${this.config.collection} < ${target} --jsonArray`;
+  let fileTypeSet = new Set(['json', 'csv', 'tsv']),
+      fileType = target.substring(target.lastIndexOf('.') + 1).toLowerCase(),
+      headerline = fileType !== 'json' ? '--headerline' : '';
+
+  if (!fileTypeSet.has(fileType)) {
+    throw new Error('Invalid file type');
+  }
+
+  return `mongoimport --host localhost --db ${this.config.db} -u ${this.config.user} -p ${this.config.pwd} --authenticationDatabase ${this.config.db} --collection ${this.config.collection} --type ${fileType} ${headerline} --file ${target}`;
 };

--- a/test/specs/querySpec.js
+++ b/test/specs/querySpec.js
@@ -2,8 +2,9 @@
 'use strict';
 // assertion library
 // /////////////////////////////////////////////////////////
-var chai = require('chai');
-var sinonChai = require('sinon-chai');
+let chai = require('chai');
+let sinonChai = require('sinon-chai');
+let expect = chai.expect;
 chai.should();
 chai.use(sinonChai);
 
@@ -17,20 +18,51 @@ let configMock = {
   }
 };
 
-let fakeTarget = 'fake.json';
+let fakeJson = 'fake.json';
+let fakeCsv = 'fake.csv';
+let fakeTsv = 'fake.tsv';
+let fakeBadFile = 'fake.jpg';
 
 // modules to test
 // /////////////////////////////////////////////////////////
 let query = require('../../lib/query');
 
 describe('query', function () {
-  it('should generate query string', function () {
-    let returnValue = query.call(configMock, fakeTarget);
-    returnValue.should.contain(`--db ${configMock.config.db}`);
-    returnValue.should.contain(`-u ${configMock.config.user}`);
-    returnValue.should.contain(`-p ${configMock.config.pwd}`);
-    returnValue.should.contain(`--authenticationDatabase ${configMock.config.db}`);
-    returnValue.should.contain(`--collection ${configMock.config.collection}`);
-    returnValue.should.contain(`${fakeTarget} --jsonArray`);
+  describe('when passed a JSON file path', function () {
+    it('should generate query string to import JSON file', function () {
+      let returnValue = query.call(configMock, fakeJson);
+      returnValue.should.contain(`--db ${configMock.config.db}`);
+      returnValue.should.contain(`-u ${configMock.config.user}`);
+      returnValue.should.contain(`-p ${configMock.config.pwd}`);
+      returnValue.should.contain(`--authenticationDatabase ${configMock.config.db}`);
+      returnValue.should.contain(`--collection ${configMock.config.collection}`);
+      returnValue.should.contain('--type json');
+      returnValue.should.not.contain('--headerline');
+      returnValue.should.contain(`--file ${fakeJson}`);
+    });
+  });
+
+  describe('when passed a CSV file path', function () {
+    it('should generate query string to import CSV file', function () {
+      let returnValue = query.call(configMock, fakeCsv);
+      returnValue.should.contain('--type csv');
+      returnValue.should.contain('--headerline');
+      returnValue.should.contain(`--file ${fakeCsv}`);
+    });
+  });
+
+  describe('when passed a TSV file path', function () {
+    it('should generate query string to import TSV file', function () {
+      let returnValue = query.call(configMock, fakeTsv);
+      returnValue.should.contain('--type tsv');
+      returnValue.should.contain('--headerline');
+      returnValue.should.contain(`--file ${fakeTsv}`);
+    });
+  });
+
+  describe('when passed an invalid file path', function () {
+    it('should throw an error', function () {
+      expect(query.bind(configMock, fakeBadFile)).to.throw('Invalid file type');
+    });
   });
 });


### PR DESCRIPTION
Allow for smart file sniffing

./lib/query.js
- now gets target file's extension and passes it into query string's "--file" flag.
- refactored query string to take "--type" and "--file" flags,
  in lieu of piping query to file.
- defined "headerline" variable to be used for CSV/TSV files. Defaults
  to empty string.
- headerline variable is assigned "--headerline" flag in mongo query
  when file type of target file is a CSV/TSV
- convert file type to lower case before proceeding with process
- check if parsed file type is a valid type. Throw error if not.

./test/specs/querySpec.js
- add tests to include checking for file types and --headerline
- add test to confirm error is thrown for invalid file type

./README.md
- Updating documentaion so #import() argument is no longer json specfic.
