### PR TITLE
bug/4 Query string for JSON data should be using "--jsonArray" flag

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3,7 +3,7 @@
 module.exports = function (target) {
   let fileTypeSet = new Set(['json', 'csv', 'tsv']),
       fileType = target.substring(target.lastIndexOf('.') + 1).toLowerCase(),
-      headerline = fileType !== 'json' ? '--headerline' : '';
+      headerline = fileType !== 'json' ? '--headerline' : '--jsonArray';
 
   if (!fileTypeSet.has(fileType)) {
     throw new Error('Invalid file type');

--- a/test/specs/querySpec.js
+++ b/test/specs/querySpec.js
@@ -38,6 +38,7 @@ describe('query', function () {
       returnValue.should.contain(`--collection ${configMock.config.collection}`);
       returnValue.should.contain('--type json');
       returnValue.should.not.contain('--headerline');
+      returnValue.should.contain('--jsonArray');
       returnValue.should.contain(`--file ${fakeJson}`);
     });
   });


### PR DESCRIPTION
Fixes #4 Query string for JSON data should be using "--jsonArray" flag

./lib/query.js
- when fileType is "json", headerline will be replaced with "--jsonArray" and included in query string

./test/specs/querySpec.js
- added test to confirm "--jsonArray" flag is correctly added.
