### PR TITLE
Resolves #2 Allow for passing object into #set()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mongonaut
-NodeJS module that totally Promises to import JSON files to MongoDB.
+NodeJS module that totally Promises to import your JSON, CSV or TSV files to MongoDB.
 
 ## Usage
 ```javascript
@@ -21,17 +21,24 @@ mongonaut.import('./data.json')
 
 **returns:** Mongonaut instance.
 
-### .set(key, val)
+
+### .set([key, val] or [config])
 **key:** desired config key to set.
 
 **val:** desired value of `mongonaut.config[key]`
 
+**config** object to apply configuration data. Available keys are `user`, `pwd`, `db`, and `collection` which are used to authenticate with MongoDB
+
+**note** trying to set a key other than `user`, `pwd`, `db` or `collection` will result in an error.
+
 **returns:** mongonaut
+
 
 ### .import(targetFile)
 **targetFile:** The file (.json, .csv, or .tsv) containing the data you wish to [import to MongoDB](https://docs.mongodb.org/manual/reference/program/mongoimport/).
 
 **returns:** [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+
 
 ## Run Tests
 In a terminal:

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ let defaults = require('./lib/defaults');
 let query = require('./lib/query');
 
 let Mongonaut = function (options) {
-  this.config = Object.assign(defaults, options);
+  this.config = Object.assign(defaults(), options);
+  Object.seal(this.config);
   this.exec = exec;
   this.query = query;
 };
@@ -24,12 +25,17 @@ Mongonaut.prototype = {
     });
   },
 
-  'set': function (prop, val) {
-    if (typeof defaults[prop] !== 'undefined') {
-      this.config[prop] = val;
+  'set': function () {
+    if (typeof arguments[0] === 'object') {
+      this.config = Object.assign(this.config, arguments[0]);
       return this;
     }
-    return false;
+    else if (typeof arguments[0] === 'string' && typeof arguments[1] === 'string') {
+      this.config[arguments[0]] = arguments[1];
+      return this;
+    }
+
+    return new Error('Invalid argument(s)');
   }
 };
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,6 +1,9 @@
-module.exports = {
-  'user': '',
-  'pwd': '',
-  'db': '',
-  'collection': ''
+'use strict';
+module.exports = function () {
+  return {
+    'user': '',
+    'pwd': '',
+    'db': '',
+    'collection': ''
+  };
 };

--- a/test/specs/mongonautSpec.js
+++ b/test/specs/mongonautSpec.js
@@ -16,6 +16,13 @@ let configMock = {
   'collection': 'mads'
 };
 
+let setMock = {
+  'user': 'dr. f',
+  'pwd': 'deep hurting',
+  'db': 'frank',
+  'collection': 'torgo'
+};
+
 // modules to test
 // /////////////////////////////////////////////////////////
 let Mongonaut = require('../../index');
@@ -42,16 +49,30 @@ describe('Mongonaut', function () {
     });
 
     describe('#set()', function () {
-      describe('when passed a property that does not exist in mongonaut.config', function () {
-        it('should not apply the new property name', function () {
-          mongonaut.set('foo', 'bar');
-          let typeValue = typeof mongonaut.config.foo;
-          typeValue.should.eql('undefined');
+      describe('when passed an object', function () {
+        it('should apply valid propeties to mongonaut.config', function () {
+          mongonaut.set(setMock);
+          mongonaut.config.user.should.eql(setMock.user);
+          mongonaut.config.db.should.eql(setMock.db);
         });
+      });
 
-        it('should return false if passed property does not exist in internal config', function () {
-          let returnValue = mongonaut.set('foo', 'bar');
-          returnValue.should.be.false;
+      describe('when not passed a strig or object', function () {
+        it('should return an error', function () {
+          let returnValue = mongonaut.set(1, 2);
+          returnValue.should.be.an.instanceOf(Error);
+        });
+      });
+
+      describe('when passed a property that does not exist in mongonaut.config', function () {
+        it('should throw an error if passed property does not exist in internal config', function () {
+          try {
+            let returnValue = mongonaut.set('foo', 'bar');
+            returnValue.should.be.an.instanceOf(Error);
+          }
+          catch (e) {
+            e.should.be.an.instanceOf(Error);
+          }
         });
       });
 


### PR DESCRIPTION
Allow for passing object into #set()

./index.js
- Checking argument(s) of #set() and determine if it should handle
  a config object, or key/value strings.`
- Will now return an error if an invalid argument is found, instead of
  'false'.
- use Object.seal() to harden mongonaut.config

./lib/defaults.js
- change "defaults" from an object to a function that returns an
  object so other mongonaut instances don't share same modified
  defaults object. This was a side effect of using Object.seal in
  ./index.js

./README.md
- update docs to relfect changes in #set()

./test/specs/mongonautSpec.js
- Updated test to reflect #set() will now return an error if the
  passed key string does not correlate to a property in
  mongonaut.config.
