### PR TITLE
Fixes #7 - config is sealed after passed options are applied during instantiation

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ let query = require('./lib/query');
 
 let Mongonaut = function (options) {
   this.config = Object.assign(defaults(), options);
-  Object.seal(this.config);
   this.exec = exec;
   this.query = query;
 };

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,9 +1,9 @@
 'use strict';
 module.exports = function () {
-  return {
+  return Object.seal({
     'user': '',
     'pwd': '',
     'db': '',
     'collection': ''
-  };
+  });
 };


### PR DESCRIPTION
./lib/defaults.js
- retuned object is now sealed

./index.js
- since object returned from lib/defaults.js is now sealed, Mongonaut's constructor no longer needs to do it, so removed Object.observe() in constructor.
