### PR TITLE
enchancement/9 - Allow for batch importing multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,18 @@ let mongonaut = new Mongonaut({
   'collection': 'movies'
 });
 
+// pass a path to data file
 mongonaut.import('./data.json')
   .then(function (response) {
     // code to fire on Promise resolve
+  });
+
+// change config to point to new collection
+// then batch import multiple files.
+mongonaut.set('collection', 'inventions');
+  .import(['./data2.json', './some/other/data.json', './third.json'])
+  .then(function (response) {
+      // code to fire on Promise resolve
   });
 ```
 
@@ -22,7 +31,7 @@ mongonaut.import('./data.json')
 **returns:** Mongonaut instance.
 
 
-### .set([key, val] or [config])
+### .set([key, val] OR [config])
 **key:** desired config key to set.
 
 **val:** desired value of `mongonaut.config[key]`
@@ -34,23 +43,35 @@ mongonaut.import('./data.json')
 **returns:** mongonaut
 
 
-### .import(targetFile)
+### .import(targetfile OR [targetFiles])
 **targetFile:** The file (.json, .csv, or .tsv) containing the data you wish to [import to MongoDB](https://docs.mongodb.org/manual/reference/program/mongoimport/).
+
+**[targetFiles]** An array of file paths containing the data you wish to import.
 
 **returns:** [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 
+Resolving callback will be passed an array of objects (1 for each file originally imported) that contain the `file` that was imported, as well
+as the `stdout` and `stderr` values.
+
 
 ## Changelog
+**v2.0.0**
+* `.import()` function can be passed either a string of the path to a single JSON file, or an array of strings each pointing to a JSON file to be imported.
+[enhancement/9](https://github.com/otterthecat/mongonaut/issues/9)
+
+* **breaking change** the returned promise from `.import()` resolving callback
+is now passed an array instead of an object.
+
 **v1.1.1**
 * Config property is now sealed before options are applied during instantiation.[bug/7](https://github.com/otterthecat/mongonaut/issues/7)
 
 **v1.1.0**
 * Can now import CSV and TSV files [enchancement/1](https://github.com/otterthecat/mongonaut/issues/1)
-* .set() function can either accept key/value arguments, or a config object [enhancement/2](https://github.com/otterthecat/mongonaut/issues/2)
+* `.set()` function can either accept key/value arguments, or a config object [enhancement/2](https://github.com/otterthecat/mongonaut/issues/2)
 * Bugfix [bug/4](https://github.com/otterthecat/mongonaut/issues/4)
 
 **v1.0.1**
-* fixed typo in .npmignore
+* fixed typo in `.npmignore`
 
 **v1.0.0**
 * Initial release

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 let exec = require('child_process').exec;
 let defaults = require('./lib/defaults');
 let query = require('./lib/query');
+let importScript = require('./lib/importScript');
 
 let Mongonaut = function (options) {
   this.config = Object.assign(defaults(), options);
@@ -11,17 +12,17 @@ let Mongonaut = function (options) {
 
 Mongonaut.prototype = {
   'import': function (target) {
-    return new Promise ((resolve, reject) => {
-      this.exec(this.query(target), (err, stdout, stderr) => {
-        if (err) {
-          reject(err);
-        }
-        resolve.call(this, {
-          'stdout': stdout,
-          'stderr': stderr
-        });
+    let promiseList = [];
+    if (typeof target === 'string') {
+      promiseList.push(importScript.call(this, target));
+    }
+    else if (Array.isArray(target)) {
+      target.forEach((item) => {
+        promiseList.push(importScript.call(this, item));
       });
-    });
+    }
+
+    return Promise.all(promiseList);
   },
 
   'set': function () {

--- a/lib/importScript.js
+++ b/lib/importScript.js
@@ -1,0 +1,15 @@
+'use strict';
+module.exports = function (target) {
+  return new Promise ((resolve, reject) => {
+    this.exec(this.query(target), (err, stdout, stderr) => {
+      if (err) {
+        reject(err);
+      }
+      resolve.call(this, {
+        'file': target,
+        'stdout': stdout,
+        'stderr': stderr
+      });
+    });
+  });
+};

--- a/test/specs/mongonautSpec.js
+++ b/test/specs/mongonautSpec.js
@@ -95,7 +95,7 @@ describe('Mongonaut', function () {
         returnValue.should.be.an.instanceOf(Promise);
       });
       it('should execute valid string', function () {
-        mongonaut.import();
+        mongonaut.import(mongonaut.query());
         mongonaut.exec.should.have.been.calledWithMatch('query-string');
       });
     });


### PR DESCRIPTION
./index.js
- check if import() argument is a string or array.
- if argument is an array, loop through them
- return Promise.all()
- .import() function will now take target file(s) and return a
  Promise.all();
- now requires new ./lib/importScript.js

./lib/importScript.js
- runs scoped .exec() which is returned wrapped in a promise.
- returned object to include "file" property which contains
  imported file's path.

./test/specs/mongonautSpec.js
- updating unit tests for `.import()`

./README.md
- upadted documentation.
