### PR TITLE
fixes #11 - Ability to disable authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ mongonaut.set('collection', 'inventions');
 ```
 
 ### Constructor(config)
-**config:** object to apply configuration data. Available keys are `user`, `pwd`, `db`, and `collection` which are used to authenticate with MongoDB
+**config:** object to apply configuration data. Available keys are `user`, `pwd`, `db`, and `collection` which are used to authenticate with MongoDB.
+
+If authentication is not desired, then simply omit setting both `user` and `pwd`, or in the case of changing settings from using authentication to omitting authtentication, set both `user` and `pwd` to empty strings.
 
 **returns:** Mongonaut instance.
 
@@ -36,7 +38,10 @@ mongonaut.set('collection', 'inventions');
 
 **val:** desired value of `mongonaut.config[key]`
 
-**config** object to apply configuration data. Available keys are `user`, `pwd`, `db`, and `collection` which are used to authenticate with MongoDB
+**config** object to apply configuration data. Available keys are `user`, `pwd`, `db`, and `collection` which are used to authenticate with MongoDB.
+
+Remember, both `user` and `pwd` must both either be set (for authentication), or set as the default/empty strings (for no authentication). Setting only one or the other
+will result in an error when you call `.import()`.
 
 **note** trying to set a key other than `user`, `pwd`, `db` or `collection` will result in an error.
 
@@ -55,6 +60,12 @@ as the `stdout` and `stderr` values.
 
 
 ## Changelog
+**v2.1.0**
+ * [enhancement/11](https://github.com/otterthecat/mongonaut/issues/11)
+  * If `user` and `pwd` configs are BOTH not set, then the mongo query will not
+invoke authentication.
+  * If a `user` config is set without a `pwd`, or vice versa, an error will be thrown.
+
 **v2.0.2**
 * updated changelog
 
@@ -62,18 +73,21 @@ as the `stdout` and `stderr` values.
 * bumped version in package.json
 
 **v2.0.0**
-* `.import()` function can be passed either a string of the path to a single JSON file, or an array of strings each pointing to a JSON file to be imported.
-[enhancement/9](https://github.com/otterthecat/mongonaut/issues/9)
+* [enhancement/9](https://github.com/otterthecat/mongonaut/issues/9)
+  * `.import()` function can be passed either a string of the path to a single JSON file, or an array of strings each pointing to a JSON file to be imported.
 
 * **breaking change** the returned promise from `.import()` resolving callback
 is now passed an array instead of an object.
 
 **v1.1.1**
-* Config property is now sealed before options are applied during instantiation.[bug/7](https://github.com/otterthecat/mongonaut/issues/7)
+* [bug/7](https://github.com/otterthecat/mongonaut/issues/7)
+  * Config property is now sealed before options are applied during instantiation.
 
 **v1.1.0**
-* Can now import CSV and TSV files [enchancement/1](https://github.com/otterthecat/mongonaut/issues/1)
-* `.set()` function can either accept key/value arguments, or a config object [enhancement/2](https://github.com/otterthecat/mongonaut/issues/2)
+* [enchancement/1](https://github.com/otterthecat/mongonaut/issues/1)
+  * `.set()` function can either accept key/value arguments, or a config object
+* [enhancement/2](https://github.com/otterthecat/mongonaut/issues/2)
+  * Can now import CSV and TSV files
 * Bugfix [bug/4](https://github.com/otterthecat/mongonaut/issues/4)
 
 **v1.0.1**

--- a/lib/query.js
+++ b/lib/query.js
@@ -3,11 +3,19 @@
 module.exports = function (target) {
   let fileTypeSet = new Set(['json', 'csv', 'tsv']),
       fileType = target.substring(target.lastIndexOf('.') + 1).toLowerCase(),
-      headerline = fileType !== 'json' ? '--headerline' : '--jsonArray';
+      headerline = fileType !== 'json' ? '--headerline' : '--jsonArray',
+      auth = '';
 
   if (!fileTypeSet.has(fileType)) {
     throw new Error('Invalid file type');
   }
 
-  return `mongoimport --host localhost --db ${this.config.db} -u ${this.config.user} -p ${this.config.pwd} --authenticationDatabase ${this.config.db} --collection ${this.config.collection} --type ${fileType} ${headerline} --file ${target}`;
+  if (this.config.user.length > 0 && this.config.pwd.length > 0) {
+    auth = `-u ${this.config.user} -p ${this.config.pwd} --authenticationDatabase ${this.config.db}`;
+  }
+  else if (this.config.user.length + this.config.pwd.length > 0) {
+    throw new Error('Missing user name or password');
+  }
+
+  return `mongoimport --host localhost --db ${this.config.db} ${auth} --collection ${this.config.collection} --type ${fileType} ${headerline} --file ${target}`;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongonaut",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "NodeJS wrapper for mongoimport",
   "homepage": "https://github.com/otterthecat/mongonaut",
   "bugs": "https://github.com/otterthecat/mongonaut/issues",

--- a/test/specs/querySpec.js
+++ b/test/specs/querySpec.js
@@ -18,6 +18,33 @@ let configMock = {
   }
 };
 
+let noAuthMock = {
+  'config': {
+    'user': '',
+    'pwd': '',
+    'db': 'sol',
+    'collection': 'bots'
+  }
+};
+
+let incompleteMock1 = {
+  'config': {
+    'user': 'foo',
+    'pwd': '',
+    'db': 'deep13',
+    'colelction': 'mads'
+  }
+};
+
+let incompleteMock2 = {
+  'config': {
+    'user': '',
+    'pwd': 'foo',
+    'db': 'deep13',
+    'colelction': 'mads'
+  }
+};
+
 let fakeJson = 'fake.json';
 let fakeCsv = 'fake.csv';
 let fakeTsv = 'fake.tsv';
@@ -40,6 +67,25 @@ describe('query', function () {
       returnValue.should.not.contain('--headerline');
       returnValue.should.contain('--jsonArray');
       returnValue.should.contain(`--file ${fakeJson}`);
+    });
+  });
+
+  describe ('when no authentication is set', function () {
+    it('should create query without authentication params', function () {
+      let returnValue = query.call(noAuthMock, fakeJson);
+      returnValue.should.not.contain('-p');
+      returnValue.should.not.contain('-u');
+      returnValue.should.not.contain('--authenticationDatabase');
+    });
+  });
+
+  describe('when only a user or pwd is set', function () {
+    it('should throw an error if missing a pwd', function () {
+      expect(query.bind(incompleteMock1, fakeJson)).to.throw('Missing user name or password');
+    });
+
+    it('should throw an error if missing a user', function () {
+      expect(query.bind(incompleteMock2, fakeJson)).to.throw('Missing user name or password');
     });
   });
 


### PR DESCRIPTION
enhancement
- lib/query.js - created "auth" substring to be used for generating
  query. If no user & pwd is set, then query will not include
  authentication. If both are set, then query will include
  authentication. If only one is set (user OR pwd), then an error is
  thrown.
- test/specs/querySpec.js - udpated unit tests to cover when user/pwd
  are both not set, and in the event one, but not the other is set
  (resulting in an error)
- package.json - updated to reflect new version
- README.md - updated documentation to make clear the authentication
  changes
