### PR TITLE
feat(config): add option to configure mongo host

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ NodeJS module that totally Promises to import your JSON, CSV or TSV files to Mon
 ## Usage
 ```javascript
 let mongonaut = new Mongonaut({
+  'host': 'localhost',
   'user': 'tomservo',
   'pwd': 'sol',
   'db': 'experiments',
@@ -32,7 +33,7 @@ mongonaut.export()
 ```
 
 ### Constructor(config)
-**config:** object to apply configuration data. Available keys are `user`, `pwd`, `db`, `collection` which are used to authenticate with MongoDB, as well as options `jsonArray` - set as `false` if you want to use MongoDB's [JSON format](http://zaiste.net/2012/08/importing_json_into_mongodb/). (by default, *Mongonaut* will expect valid JSON files),
+**config:** object to apply configuration data. Available keys are `host`, `user`, `pwd`, `db`, `collection` which are used to authenticate with MongoDB, as well as options `jsonArray` - set as `false` if you want to use MongoDB's [JSON format](http://zaiste.net/2012/08/importing_json_into_mongodb/). (by default, *Mongonaut* will expect valid JSON files),
 and `upsertFields` if you need to [specify fields](https://docs.mongodb.com/manual/reference/program/mongoimport/#cmdoption--upsertFields)
 
 If authentication is not desired, then simply omit setting both `user` and `pwd`, or in the case of changing settings from using authentication to omitting authtentication, set both `user` and `pwd` to empty strings.
@@ -45,7 +46,7 @@ If authentication is not desired, then simply omit setting both `user` and `pwd`
 
 **val:** desired value of `mongonaut.config[key]`
 
-**config** object to apply configuration data. Available keys are `user`, `pwd`, `db`, and `collection` which are used to authenticate with MongoDB.
+**config** object to apply configuration data. Available keys are `host`, `user`, `pwd`, `db`, and `collection` which are used to authenticate with MongoDB.
 
 If you intend to use [MongoDB's default JSON formatting](http://zaiste.net/2012/08/importing_json_into_mongodb/), then set `jsonArray` to false.
 
@@ -54,7 +55,7 @@ You can set `upsertFields` if you intend to specify specific fields for your que
 Remember, both `user` and `pwd` must both either be set (for authentication), or set as the default/empty strings (for no authentication). Setting only one or the other
 will result in an error when you call `.import()`.
 
-**note** trying to set a key other than `user`, `pwd`, `db` or `collection` will result in an error.
+**note** trying to set a key other than `host`, `user`, `pwd`, `db` or `collection` will result in an error.
 
 **returns:** mongonaut
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,6 +1,7 @@
 'use strict';
 module.exports = function () {
   return Object.seal({
+    'host': '',
     'user': '',
     'pwd': '',
     'db': '',

--- a/lib/query.js
+++ b/lib/query.js
@@ -13,12 +13,12 @@ exports.import = function (target) {
     throw new Error('Invalid file type');
   }
 
-  return `mongoimport --host localhost --db ${this.config.db} ${auth} --collection ${this.config.collection} --type ${fileType} ${headerline} ${upsertfields} --file ${target}`;
+  return `mongoimport --host ${this.config.host} --db ${this.config.db} ${auth} --collection ${this.config.collection} --type ${fileType} ${headerline} ${upsertfields} --file ${target}`;
 };
 
 exports.export = function (collection) {
   collection = collection || this.config.collection;
   let auth = generateAuth(this.config) || '';
 
-  return `mongoexport --host localhost --db ${this.config.db} ${auth} --collection ${collection} --jsonArray -o ${collection}.json`;
+  return `mongoexport --host ${this.config.host} --db ${this.config.db} ${auth} --collection ${collection} --jsonArray -o ${collection}.json`;
 };

--- a/test/specs/mongonautSpec.js
+++ b/test/specs/mongonautSpec.js
@@ -10,6 +10,7 @@ chai.use(sinonChai);
 
 // mock data
 let configMock = {
+  'host': 'localhost',
   'user': 'tomservo',
   'pwd': 'lemur',
   'db': 'deep13',
@@ -17,6 +18,7 @@ let configMock = {
 };
 
 let setMock = {
+  'host': 'localhost',
   'user': 'dr. f',
   'pwd': 'deep hurting',
   'db': 'frank',
@@ -43,6 +45,7 @@ describe('Mongonaut', function () {
 
   describe('instnace', function () {
     it('should apply passed object to internal config property', function () {
+      mongonaut.config.host.should.eql(configMock.host);
       mongonaut.config.user.should.eql(configMock.user);
       mongonaut.config.pwd.should.eql(configMock.pwd);
       mongonaut.config.db.should.eql(configMock.db);
@@ -53,6 +56,7 @@ describe('Mongonaut', function () {
       describe('when passed an object', function () {
         it('should apply valid propeties to mongonaut.config', function () {
           mongonaut.set(setMock);
+          mongonaut.config.host.should.eql(configMock.host);
           mongonaut.config.user.should.eql(setMock.user);
           mongonaut.config.db.should.eql(setMock.db);
         });

--- a/test/specs/querySpec.js
+++ b/test/specs/querySpec.js
@@ -11,6 +11,7 @@ chai.use(sinonChai);
 // mock data
 let configMock = {
   'config': {
+    'host': 'localhost',
     'user': 'tomservo',
     'pwd': 'lemur',
     'db': 'deep13',
@@ -21,6 +22,7 @@ let configMock = {
 
 let configUpsertMock = {
   'config': {
+    'host': 'localhost',
     'user': 'tomservo',
     'pwd': 'lemur',
     'db': 'deep13',
@@ -32,6 +34,7 @@ let configUpsertMock = {
 
 let configMultipleUpsertMock = {
   'config': {
+    'host': 'localhost',
     'user': 'tomservo',
     'pwd': 'lemur',
     'db': 'deep13',
@@ -43,6 +46,7 @@ let configMultipleUpsertMock = {
 
 let noAuthMock = {
   'config': {
+    'host': 'localhost',
     'user': '',
     'pwd': '',
     'db': 'sol',
@@ -52,6 +56,7 @@ let noAuthMock = {
 
 let incompleteMock1 = {
   'config': {
+    'host': 'localhost',
     'user': 'foo',
     'pwd': '',
     'db': 'deep13',
@@ -61,6 +66,7 @@ let incompleteMock1 = {
 
 let incompleteMock2 = {
   'config': {
+    'host': 'localhost',
     'user': '',
     'pwd': 'foo',
     'db': 'deep13',
@@ -83,6 +89,7 @@ describe('#import', function () {
   describe('when passed a JSON file path', function () {
     it('should generate query string to import JSON file', function () {
       let returnValue = imp.call(configMock, fakeJson);
+      returnValue.should.contain(`--host ${configMock.config.host}`);
       returnValue.should.contain(`--db ${configMock.config.db}`);
       returnValue.should.contain(`-u ${configMock.config.user}`);
       returnValue.should.contain(`-p ${configMock.config.pwd}`);


### PR DESCRIPTION
The current version doesn't support the configuration of the mongo host.
However, change host can be usefull if the database is running on a VM or another machine.
I already use my forked version on a project and it work fine !
